### PR TITLE
allow passing in of options for translate

### DIFF
--- a/app-addon/helpers/i18next.js
+++ b/app-addon/helpers/i18next.js
@@ -2,6 +2,6 @@
 
 import Ember from 'ember';
 
-export default function(key, post) {
-  return new Ember.Handlebars.SafeString(i18n.t(key, post ? { postProcess: post } : {}));
+export default function(key, options) {
+  return new Ember.Handlebars.SafeString(i18n.t(key, options.hash || {}));
 }


### PR DESCRIPTION
usage

```javascript
{{t 'product' count=model.length postProcess='productHandler'}}
```

this is a breaking change. Though I think it could be changed to still accept the post postProcess option

```javascript
function(key, post, options) { ... }
```